### PR TITLE
feat(duckdb): add duckdb port

### DIFF
--- a/ports/duckdb/portfile.cmake
+++ b/ports/duckdb/portfile.cmake
@@ -1,0 +1,47 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO duckdb/duckdb
+    REF v${VERSION}
+    SHA512 9f3f470aeaecc65506ec66183bef4b039cf2a23685ce8c876ce9862e9c5746e8150ace3d37acf167f15611f2bf078f85e8ed0b397397d7391fc044a75c59271a
+)
+
+# Set the build environment variables and configure options
+vcpkg_cmake_configure(
+        SOURCE_PATH ${SOURCE_PATH}
+        OPTIONS
+            -DBUILD_UNITTESTS=OFF
+            -DBUILD_SHELL=FALSE
+            -DBUILD_EXTENSIONS=httpfs;json;parquet
+            -DENABLE_EXTENSION_AUTOLOADING=1
+            -DENABLE_EXTENSION_AUTOINSTALL=1
+)
+vcpkg_cmake_install()
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/CMake")
+    vcpkg_cmake_config_fixup(CONFIG_PATH CMake)
+elseif(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/DuckDB")
+    vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/DuckDB")
+elseif(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/${PORT}")
+    vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/${PORT}")
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL static)
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
+endif()
+
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/DuckDBConfig.cmake"
+  [[set(DuckDB_INCLUDE_DIRS "${DuckDB_CMAKE_DIR}/include")]]
+
+  [[get_filename_component(DuckDB_INCLUDE_DIRS "${DuckDB_CMAKE_DIR}" PATH)
+    get_filename_component(DuckDB_INCLUDE_DIRS "${DuckDB_INCLUDE_DIRS}" PATH)
+    set(DuckDB_INCLUDE_DIRS "${DuckDB_INCLUDE_DIRS}/include")]]
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/duckdb/storage/serialization")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")
+
+message(STATUS "Installed ${PORT} ${VERSION}")

--- a/ports/duckdb/usage
+++ b/ports/duckdb/usage
@@ -1,0 +1,6 @@
+The package duckdb provides CMake targets:
+
+    find_package(DuckDB CONFIG REQUIRED)
+    find_package(Threads REQUIRED)
+    target_include_directories(main PRIVATE ${DuckDB_INCLUDE_DIRS})
+    target_link_libraries(main PRIVATE duckdb)

--- a/ports/duckdb/vcpkg.json
+++ b/ports/duckdb/vcpkg.json
@@ -1,0 +1,18 @@
+{
+  "name": "duckdb",
+  "version": "1.0.0",
+  "description": "DuckDB is an analytical in-process SQL database management system",
+  "homepage": "https://duckdb.org",
+  "license": "MIT",
+  "supports": "!(uwp | android | (windows & arm64))",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
Modeled after this [in-progress port for duckdb using v0.9](https://github.com/microsoft/vcpkg/pull/34607):
- stripped out all the extension feature options and just hardcoded the ones I believe we'll need b/c I couldn't get it working with
- removed all the patches, seem to be irrelevant or fixed upstream (v1.0)
