### PR TITLE
chore: Add boost crc as libndtp depends

### DIFF
--- a/ports/science-libndtp/vcpkg.json
+++ b/ports/science-libndtp/vcpkg.json
@@ -13,7 +13,8 @@
       "name": "vcpkg-cmake-config",
       "host": true
     },
-    "protobuf"
+    "protobuf",
+    "boost-crc"
   ],
   "features": {
     "tests": {


### PR DESCRIPTION
# Summary
After a ton of discussion and testing ([see here](https://science-sig6580.slack.com/archives/C03UAC8PQ2V/p1736545111412859) I gave up on trying to sync vcpkg.json and/or use vcpkg_from_git (because of the submodule issues).

This adds the correct dependency to fix libndtp builds. 

