### PR TITLE
Fixed onnxruntime build issues with eigen and fixed cross-compilation to ARM64

### DIFF
--- a/ports/onnxruntime/patches/fix-eigen-sha1.patch
+++ b/ports/onnxruntime/patches/fix-eigen-sha1.patch
@@ -1,0 +1,18 @@
+--- a/cmake/deps.txt.orig	2025-08-12 17:03:45.715075855 -0700
++++ b/cmake/deps.txt	2025-08-12 17:05:23.447553155 -0700
+@@ -11,7 +11,7 @@
+ cxxopts;https://github.com/jarro2783/cxxopts/archive/3c73d91c0b04e2b59462f0a741be8c07024c1bc0.zip;6c6ca7f8480b26c8d00476e0e24b7184717fe4f0
+ date;https://github.com/HowardHinnant/date/archive/refs/tags/v2.4.1.zip;ea99f021262b1d804a872735c658860a6a13cc98
+ dlpack;https://github.com/dmlc/dlpack/archive/refs/tags/v0.6.zip;4d565dd2e5b31321e5549591d78aa7f377173445
+-eigen;https://gitlab.com/libeigen/eigen/-/archive/e7248b26a1ed53fa030c5c459f7ea095dfd276ac/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip;be8be39fdbc6e60e94fa7870b280707069b5b81a
++eigen;https://gitlab.com/libeigen/eigen/-/archive/e7248b26a1ed53fa030c5c459f7ea095dfd276ac/eigen-e7248b26a1ed53fa030c5c459f7ea095dfd276ac.zip;32b145f525a8308d7ab1c09388b2e288312d8eba
+ flatbuffers;https://github.com/google/flatbuffers/archive/refs/tags/v1.12.0.zip;ba0a75fd12dbef8f6557a74e611b7a3d0c5fe7bf
+ fp16;https://github.com/Maratyszcza/FP16/archive/0a92994d729ff76a58f692d3028ca1b64b145d91.zip;b985f6985a05a1c03ff1bb71190f66d8f98a1494
+ fxdiv;https://github.com/Maratyszcza/FXdiv/archive/63058eff77e11aa15bf531df5dd34395ec3017c8.zip;a5658f4036402dbca7cebee32be57fb8149811e1
+@@ -42,4 +42,4 @@
+ safeint;https://github.com/dcleblanc/SafeInt/archive/ff15c6ada150a5018c5ef2172401cb4529eac9c0.zip;913a4046e5274d329af2806cb53194f617d8c0ab
+ tensorboard;https://github.com/tensorflow/tensorboard/archive/373eb09e4c5d2b3cc2493f0949dc4be6b6a45e81.zip;67b833913605a4f3f499894ab11528a702c2b381
+ cutlass;https://github.com/NVIDIA/cutlass/archive/refs/tags/v3.0.0.zip;0f95b3c1fc1bd1175c4a90b2c9e39074d1bccefd
+-extensions;https://github.com/microsoft/onnxruntime-extensions/archive/94142d8391c9791ec71c38336436319a2d4ac7a0.zip;4365ac5140338b4cb75a39944a4be276e3829b3c
+\ No newline at end of file
++extensions;https://github.com/microsoft/onnxruntime-extensions/archive/94142d8391c9791ec71c38336436319a2d4ac7a0.zip;4365ac5140338b4cb75a39944a4be276e3829b3c

--- a/ports/onnxruntime/patches/use-build-log-file.patch
+++ b/ports/onnxruntime/patches/use-build-log-file.patch
@@ -4,14 +4,14 @@ index 9deb447572..55780739ff 100644
 +++ b/tools/python/util/logger.py
 @@ -4,7 +4,18 @@
  import logging
- 
- 
+
+
 -def get_logger(name):
 -    logging.basicConfig(format="%(asctime)s %(name)s [%(levelname)s] - %(message)s", level=logging.DEBUG)
 +def get_logger(name, level=logging.DEBUG):
 +    formatter = logging.Formatter("%(asctime)s %(name)s [%(levelname)s] - %(message)s")
 +    logger = logging.getLogger(name)
- 
+
 -    return logging.getLogger(name)
 +    file_handler = logging.FileHandler(f"build.log")
 +    file_handler.setFormatter(formatter)

--- a/ports/onnxruntime/portfile.cmake
+++ b/ports/onnxruntime/portfile.cmake
@@ -22,6 +22,7 @@ vcpkg_from_github(
         "patches/fix-ep-headers.patch"
         "patches/use-env-build-dir.patch"
         "patches/use-build-log-file.patch"
+        "patches/fix-eigen-sha1.patch"
 )
 
 # Configuration Options
@@ -34,7 +35,7 @@ set(generator "Unix Makefiles")
 set(Z_VCPKG_CMAKE_GENERATOR ${generator} CACHE INTERNAL "The generator which was used to configure CMake.")
 
 set(build_command "${SOURCE_PATH}/build.sh")
-set(build_options --parallel --skip_submodule_sync --cmake_generator ${generator})
+set(build_options --parallel --skip_submodule_sync --cmake_generator ${generator} --allow_running_as_root)
 set(cmake_extra_defines "ONNXRUNTIME_VERSION=${VERSION}")
 
 if (NOT WITH_TESTS)
@@ -62,10 +63,40 @@ if (VCPKG_TARGET_IS_OSX)
     endif()
 
 elseif (VCPKG_TARGET_IS_LINUX)
+    # linux_arch provides mapping from architecture name to name used in triplet for cuDNN installation location
     if (VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
         set(target_arch "x64")
+        set(linux_arch "x84_64")
     elseif (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
         set(target_arch "aarch64")
+        set(linux_arch "aarch64")
+        # Need to pass --arm64 to onnxruntime's build.sh -> ci_build.py to target arm64 and enable cross-compiling
+        set(build_options ${build_options} --arm64)
+    else()
+        message(FATAL_ERROR "Unsupported architecture: ${VCPKG_TARGET_ARCHITECTURE}")
+    endif()
+
+    # used downstream on onnxruntime's CMake
+    list(APPEND cmake_extra_defines "CMAKE_SYSTEM_PROCESSOR=${linux_arch}")
+    list(APPEND cmake_extra_defines "CMAKE_SYSTEM_NAME=Linux")
+
+    if (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+        # Detect host architecture and check if we're cross-compiling
+        execute_process(COMMAND uname -m OUTPUT_VARIABLE HOST_ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
+        message(STATUS "Host architecture: ${HOST_ARCH}")
+
+        if (NOT HOST_ARCH STREQUAL "aarch64")
+            message(STATUS "Cross-compiling from ${HOST_ARCH} to arm64")
+
+            if (EXISTS "/usr/bin/${target_arch}-linux-gnu-gcc")
+                message(STATUS "Using ${target_arch}-linux-gnu cross-compiler")
+                # onnxruntime's CMake needs to know the location of our cross-compilers
+                list(APPEND cmake_extra_defines "CMAKE_C_COMPILER=/usr/bin/${target_arch}-linux-gnu-gcc")
+                list(APPEND cmake_extra_defines "CMAKE_CXX_COMPILER=/usr/bin/${target_arch}-linux-gnu-g++")
+            else()
+                message(WARNING "No ARM64 cross-compiler found. Build may fail.")
+            endif()
+        endif()
     endif()
 
     set(cuda_architectures "")
@@ -89,10 +120,17 @@ elseif (VCPKG_TARGET_IS_LINUX)
     
     if (cuda_enabled)
         list(JOIN cuda_architectures "\\;" cuda_architectures)
-        set(cmake_extra_defines ${cmake_extra_defines} CUDA_ARCHITECTURES=${cuda_architectures})
+        list(APPEND cmake_extra_defines "CUDA_ARCHITECTURES=${cuda_architectures}")
 
+        # onnxruntime needs to know where our cuda and cuDNN installations are
         set(CUDA_HOME "/usr/local/cuda")
-        set(CUDNN_HOME "/usr/lib/${target_arch}-linux-gnu/")
+        if (target_arch STREQUAL "aarch64")
+            set(CUDNN_HOME "/usr/lib/aarch64-linux-gnu/")
+        elseif (target_arch STREQUAL "x64")
+            set(CUDNN_HOME "/usr/lib/x86_64-linux-gnu/")
+        else()
+            set(CUDNN_HOME "/usr/lib/${linux_arch}-linux-gnu/")
+        endif()
         set(build_options ${build_options} --cuda_home ${CUDA_HOME} --cudnn_home ${CUDNN_HOME} --use_cuda)
     endif()
 endif()


### PR DESCRIPTION
# Summary
* Fixed build issue that onnxruntime v1.16.3 had regarding the building of one of its dependencies: eigen
* Fixed issues with cross-compilation to ARM64
# Changes
* Added a patch file `fix-eigen-sha1.patch` that changed the SHA1 hash of eigen to the correct one in onnxruntime-1.16.3/cmake/deps.txt. This was an issue that various other people had and was fixed in later versions of onnxruntime by also fixing the SHA1 hash. The reason for the change of the hash seems to be that onnxruntime had a link to a metapackage of eigen, and thus the contents were changed the moment it was updated. Refer to the following threads:
  * https://github.com/microsoft/onnxruntime/issues/18286
  * https://github.com/microsoft/onnxruntime/pull/18290
  *  https://github.com/microsoft/onnxruntime/issues/25098
*  Fixed cross-compilation issues to ARM64. The following seems to have been necessary:
    * Pass the --arm64 flag to onnxruntime's build.sh to enable cross-compilation to ARM64
    *  Assign paths to CMAKE_C_COMPILER and CMAKE_CXX_COMPILER so that onnxruntime knows which cross-compiler to use
    *  Assign values to CMAKE_SYSTEM_PROCESSOR and CMAKE_SYSTEM_NAME
    *  Fixed issues with appending by using list(APPEND...) instead of set(x ${x} ...) because empty appended variables would result in a space that the build systems further downstream couldn't parse
    *  Passed correct arguments for --cuda_home and -cudnn_home for onnxruntime's build system. Notably, having x64 as the target architecture results in x86_64 as the initial part of the triplet for cudnn_home, *not* x64.
# Testing
Added onnxruntime as a dependency in headstage/vcpkg.json and built with headstage/build.sh -a -b, targeting for ARM64, which resulted in a successful build. Verified it's being built for ARM64 by running
```
file /vcpkg/vcpkg_installed/arm64-linux-dynamic-release/lib/libonnxruntime.so.1.16.3
```
outputting
```
ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV)
```
rather than
```
ELF 64-bit LSB shared object, x86-64, version 1 (SYSV)
```
which was the case prior to the cross-compilation fixes.